### PR TITLE
(metadata) require puppetlabs/mysql >= 12.0.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 10.0.0 < 13.0.0"
+      "version_requirement": ">= 12.0.2 < 13.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
12.0.2 adds support for AlmaLinux, which is a supported OS for this package.